### PR TITLE
Log query spec on operational failures.

### DIFF
--- a/mongo_proxy/durable_cursor.py
+++ b/mongo_proxy/durable_cursor.py
@@ -150,7 +150,10 @@ OperationFailure exception catches a lot of failure cases.
 The current exception is actually:
 {exc}
 TODO: Inspect the exc name and only reload the cursor on timeouts.
-""".strip().format(exc=exc))
+
+The query spec that timed out was:
+{spec}
+""".strip().format(exc=exc, spec=self.spec))
 
             # Try to reload the cursor and continue where we left off
             self.reload_cursor()


### PR DESCRIPTION
To get a better idea of what types of queries are causing timeouts and
other operational failures.
