### PR TITLE
Add simple CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,28 @@
+name: Python package
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+    - name: Install and import
+      run: |
+        python -m pip install -e .
+        python -c "import mongo_proxy"


### PR DESCRIPTION
This mix of an issue and a pullrequest. This pr ensures a simple install and import of this package does not fail.

Which sadly currently it does:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/runner/work/MongoDBProxy/MongoDBProxy/mongo_proxy/__init__.py", line 1, in <module>
    from .mongodb_proxy import MongoProxy
  File "/home/runner/work/MongoDBProxy/MongoDBProxy/mongo_proxy/mongodb_proxy.py", line 58, in <module>
    from pymongo import Connection, ReplicaSetConnection
ImportError: cannot import name 'Connection' from 'pymongo' (/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pymongo/__init__.py)
``` 